### PR TITLE
Script to run automatic tests

### DIFF
--- a/bin/run_test.py
+++ b/bin/run_test.py
@@ -33,7 +33,7 @@ def remove_fields(data, fields):
 
 def main():
     parser = argparse.ArgumentParser(description='Test rtl_433')
-    parser.add_argument('-c', '--rtl433-cmd',
+    parser.add_argument('-c', '--rtl433-cmd', default="rtl_433",
                    help='rtl_433 command')
     parser.add_argument('-I', '--ignore-field', default=[], action="append",
                    help='Field to ignore in JSON data')

--- a/bin/run_test.py
+++ b/bin/run_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+import sys
+import os
+import argparse
+
+import fnmatch
+import subprocess
+import json
+
+from deepdiff import DeepDiff
+
+def run_rtl433(input_fn, rtl_433_cmd="rtl_433"):
+    cmd = [rtl_433_cmd, '-F', 'json', '-r', input_fn]
+    #print(" ".join(cmd))
+    p = subprocess.Popen(cmd,
+          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    return (out, err)
+
+def find_json():
+    matches = []
+    for root, dirnames, filenames in os.walk('tests'):
+        for filename in fnmatch.filter(filenames, '*.json'):
+            matches.append(os.path.join(root, filename))
+    return matches
+
+def remove_fields(data, fields):
+    for field in fields:
+        if field in data:
+            del data[field]
+    return data
+
+def main():
+    parser = argparse.ArgumentParser(description='Test rtl_433')
+    parser.add_argument('-c', '--rtl433-cmd',
+                   help='rtl_433 command')
+    parser.add_argument('-I', '--ignore-field', default=[], action="append",
+                   help='Field to ignore in JSON data')
+    args = parser.parse_args()
+
+    rtl_433_cmd = args.rtl433_cmd
+    ignore_fields = args.ignore_field
+
+    expected_json = find_json()
+    for output_fn in expected_json:
+        input_fn = os.path.splitext(output_fn)[0] + ".data"
+        if not os.path.isfile(input_fn):
+            print("WARNING: Missing '%s'" % input_fn)
+            continue
+
+        # Run rtl_433
+        rtl433out, err = run_rtl433(input_fn, rtl_433_cmd)
+
+        # get JSON results, keep only first line for now
+        rtl433out = rtl433out.strip()
+        rtl433out = rtl433out.split("\n")[0]
+        results = json.loads(rtl433out)
+        results = remove_fields(results, ignore_fields)
+
+        # Open expected data
+        with open(output_fn, "r") as output_file:
+            expected_data = json.load(output_file)
+            expected_data = remove_fields(expected_data, ignore_fields)
+
+        # Compute the diff
+        diff = DeepDiff(expected_data, results)
+        if(diff):
+            print("## Fail with '%s':" % input_fn)
+            for error, details in diff.items():
+                print(" %s" %error)
+                for detail in details:
+                    print("  * %s" %detail)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/oregon_scientific/05/THGR122N_188_54_ch1.json
+++ b/tests/oregon_scientific/05/THGR122N_188_54_ch1.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:02:39", "model" : "Weather Sensor THGR122N", "id" : 248, "channel" : 1, "battery" : "OK", "temperature_C" : 18.799999, "humidity" : 54}

--- a/tests/oregon_scientific/05/THGR122N_206_58_ch1.json
+++ b/tests/oregon_scientific/05/THGR122N_206_58_ch1.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:03:07", "model" : "Weather Sensor THGR122N", "id" : 248, "channel" : 1, "battery" : "OK", "temperature_C" : 20.600000, "humidity" : 58}

--- a/tests/oregon_scientific/05/THN132N_180_ch3.json
+++ b/tests/oregon_scientific/05/THN132N_180_ch3.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:03:42", "model" : "Thermo Sensor THN132N", "id" : 231, "channel" : 4, "battery" : "OK", "temperature_C" : 18.000000}

--- a/tests/oregon_scientific/05/THN132N_202_ch1.json
+++ b/tests/oregon_scientific/05/THN132N_202_ch1.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 20:53:24", "model" : "Thermo Sensor THN132N", "id" : 125, "channel" : 1, "battery" : "OK", "temperature_C" : 20.200001}

--- a/tests/prologue/02/prologue_146_90_ch3_btn.json
+++ b/tests/prologue/02/prologue_146_90_ch3_btn.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:07:34", "model" : "Prologue sensor", "id" : 5, "rid" : 167, "channel" : 3, "battery" : "OK", "button" : 1, "temperature_C" : 14.600000, "humidity" : 90}

--- a/tests/prologue/02/prologue_191_60_ch2.json
+++ b/tests/prologue/02/prologue_191_60_ch2.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:08:31", "model" : "Prologue sensor", "id" : 5, "rid" : 29, "channel" : 2, "battery" : "OK", "button" : 0, "temperature_C" : 19.100000, "humidity" : 60}

--- a/tests/prologue/02/prologue_199_56_ch1.json
+++ b/tests/prologue/02/prologue_199_56_ch1.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:09:32", "model" : "Prologue sensor", "id" : 5, "rid" : 37, "channel" : 1, "battery" : "OK", "button" : 0, "temperature_C" : 19.900000, "humidity" : 56}

--- a/tests/prologue/02/prologue_204_55_ch3.json
+++ b/tests/prologue/02/prologue_204_55_ch3.json
@@ -1,0 +1,1 @@
+{"time" : "2015-12-06 22:08:54", "model" : "Prologue sensor", "id" : 5, "rid" : 167, "channel" : 3, "battery" : "OK", "button" : 0, "temperature_C" : 20.400000, "humidity" : 55}


### PR DESCRIPTION
Modest script to run automatic test on repository sample data. It looks for all `.json` files under the `tests` dir and compare it to rtl_433 output ran over same file with `.data` ext.

It depends on [deepdiff](http://deepdiff.readthedocs.org/), to install it:

    $ pip install deeddiff

To run the tests:

    $ python bin/run_test.py -I time

The option `-I time` is to ignore "time" field. Something  better may be done to manage time check...

One can also specify `rtl_433` path:

     $ python bin/run_test.py -c "../build/src/rtl_433" -I time

This may be largely improved. However I prefer to share quickly.

The PR also contains some expected json samples.

Also, I see that README.md refer to a "make test" however I didn't find any makefile...
