### PR TITLE
Derive rtl_433 -f/-s from sample filename so FSK min/max path is tested

### DIFF
--- a/bin/refresh_all.py
+++ b/bin/refresh_all.py
@@ -9,13 +9,16 @@ import fnmatch
 import subprocess
 import json
 
-def run_rtl433(input_fn, samplerate=None, protocol=None, rtl_433_cmd="rtl_433"):
+from sample_params import rtl433_args
+
+def run_rtl433(input_fn, protocol=None, rtl_433_cmd="rtl_433"):
     """Run rtl_433 and return output."""
     args = ['-c', '0']
     if protocol:
         args.extend(['-R', str(protocol)])
-    if samplerate:
-        args.extend(['-s', str(samplerate)])
+    # Derive -f/-s from the filename (and per-dir override files), identical to
+    # run_test.py, so regenerated references match what the test harness runs.
+    args.extend(rtl433_args(input_fn))
     args.extend(['-F', 'json', '-r', input_fn])
     cmd = [rtl_433_cmd] + args
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -51,12 +54,6 @@ def convert(root, filename, rtl_path):
         print("WARNING: Ignoring '%s'" % input_fn)
         return
 
-    samplerate = 250000
-    samplerate_fn = os.path.join(os.path.dirname(output_fn), "samplerate")
-    if os.path.isfile(samplerate_fn):
-        with open(samplerate_fn, "r") as samplerate_file:
-            samplerate = int(samplerate_file.readline())
-
     protocol = None
     protocol_fn = os.path.join(os.path.dirname(output_fn), "protocol")
     if os.path.isfile(protocol_fn):
@@ -73,7 +70,7 @@ def convert(root, filename, rtl_path):
         expected_model = get_model_from_json(old_data[0])
 
     # Run rtl_433
-    out, _err, exitcode = run_rtl433(input_fn, samplerate, protocol, rtl_path)
+    out, _err, exitcode = run_rtl433(input_fn, protocol, rtl_path)
 
     if exitcode:
         print("ERROR: Exited with %d '%s'" % (exitcode, input_fn))

--- a/bin/run_test.py
+++ b/bin/run_test.py
@@ -12,6 +12,8 @@ import json
 
 from deepdiff import DeepDiff
 
+from sample_params import rtl433_args
+
 
 def run_rtl433(input_fn, protocol=None, config=None, rtl_433_cmd="rtl_433"):
     """Run rtl_433 and return output."""
@@ -20,6 +22,10 @@ def run_rtl433(input_fn, protocol=None, config=None, rtl_433_cmd="rtl_433"):
         args.extend(['-R', str(protocol)])
     if config:
         args.extend(['-c', str(config)])
+    # Derive -f/-s from the filename so the FSK slicer auto-selects correctly
+    # (min/max above 800 MHz); otherwise file replay defaults to 433.92 MHz
+    # and the min/max code path is never exercised.
+    args.extend(rtl433_args(input_fn))
     args.extend(['-F', 'json', '-r', input_fn])
     cmd = [rtl_433_cmd] + args
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/bin/sample_params.py
+++ b/bin/sample_params.py
@@ -1,0 +1,74 @@
+"""Derive rtl_433 frequency/sample-rate arguments for a sample file.
+
+Frequency and sample rate are read from the sample filename, e.g.
+``name_915M_1000k.cu8`` -> 915 MHz, 1000 kS/s.  Passing the real frequency
+matters because rtl_433's FSK pulse-detector auto-selection switches to the
+min/max slicer above 800 MHz (``FSK_PULSE_DETECTOR_LIMIT``); without ``-f`` a
+file replay defaults to 433.92 MHz and always uses the classic slicer, so the
+min/max code path was never exercised by the test suite.
+
+Per-directory ``frequency`` / ``samplerate`` override files take precedence
+over the filename when present (one integer in Hz on the first line).
+"""
+
+import os
+import re
+
+# Match a trailing "_<num>M" / "_<num>k" token (followed by "_" or the
+# extension dot), allowing a decimal part, e.g. _915M_, _303.3M_, _1000k.
+_FREQ_RE = re.compile(r'_(\d+(?:\.\d+)?)M(?=[._])')
+_RATE_RE = re.compile(r'_(\d+(?:\.\d+)?)k(?=[._])')
+
+DEFAULT_SAMPLERATE = 250000
+
+
+def parse_params(input_fn):
+    """Return (frequency_hz, samplerate_hz) for a sample file.
+
+    frequency is None when the filename carries no (non-zero) frequency, in
+    which case rtl_433's default applies and the classic slicer is used.
+    samplerate falls back to DEFAULT_SAMPLERATE.
+    """
+    base = os.path.basename(input_fn)
+    directory = os.path.dirname(input_fn)
+
+    freq = None
+    found = _FREQ_RE.findall(base)
+    if found:
+        hz = round(float(found[-1]) * 1e6)
+        if hz > 0:
+            freq = hz
+
+    rate = None
+    found = _RATE_RE.findall(base)
+    if found:
+        rate = round(float(found[-1]) * 1e3)
+
+    freq_fn = os.path.join(directory, "frequency")
+    if os.path.isfile(freq_fn):
+        with open(freq_fn) as fh:
+            line = fh.readline().strip()
+        if line:
+            freq = int(line)
+
+    rate_fn = os.path.join(directory, "samplerate")
+    if os.path.isfile(rate_fn):
+        with open(rate_fn) as fh:
+            line = fh.readline().strip()
+        if line:
+            rate = int(line)
+
+    if rate is None:
+        rate = DEFAULT_SAMPLERATE
+    return freq, rate
+
+
+def rtl433_args(input_fn):
+    """Build the ``-f``/``-s`` argument list for an rtl_433 invocation."""
+    freq, rate = parse_params(input_fn)
+    args = []
+    if freq:
+        args.extend(["-f", str(freq)])
+    if rate:
+        args.extend(["-s", str(rate)])
+    return args


### PR DESCRIPTION
Testing a replay of a CU8/CU16 file ignores the capture frequency unless it is passed explicitly. rtl_433 defaults to 433.92 MHz and always selects the classic FSK slicer. This means captures above 800MHz are tested against the classic slicer, which doesn't match default rtl_433 behaviour.

This updates the test scripts so samples can include a sample rate override in the filename and sets the minmax slicer for captures it runs on by default.