### PR TITLE
Handle invalid samplerate files with unit suffix support

### DIFF
--- a/bin/refresh_all.py
+++ b/bin/refresh_all.py
@@ -51,11 +51,23 @@ def convert(root, filename, rtl_path):
         print("WARNING: Ignoring '%s'" % input_fn)
         return
 
-    samplerate = 250000
     samplerate_fn = os.path.join(os.path.dirname(output_fn), "samplerate")
+    samplerate = 250000
     if os.path.isfile(samplerate_fn):
         with open(samplerate_fn, "r") as samplerate_file:
-            samplerate = int(samplerate_file.readline())
+            raw = samplerate_file.readline().strip()
+            try:
+                samplerate = int(raw)
+            except ValueError:
+                try:
+                    val = float(raw.rstrip("kKmM"))
+                    if raw.lower().endswith("k"):
+                        val *= 1000
+                    elif raw.lower().endswith("m"):
+                        val *= 1000000
+                    samplerate = int(val)
+                except ValueError:
+                    print("WARNING: Invalid samplerate '%s' in %s" % (raw, samplerate_fn))
 
     protocol = None
     protocol_fn = os.path.join(os.path.dirname(output_fn), "protocol")


### PR DESCRIPTION
Hi zuckschwerdt,

Thanks for the feedback on the previous PR. I've updated the approach based on your suggestions:

- Removed the redundant empty-file check (same error as ValueError)
- Added support for float values with k/M unit suffixes (e.g. "250k", "1.5M")
- Kept the newline at EOF as-is
- Falls back to 250000 on any parse failure with a warning

The fix now handles the actual failure mode cleanly: `int()` fails on non-integer content, and the fallback parses common rate formats before giving up.

Let me know if you'd like any adjustments.