### PR TITLE
Fineoffset-WH52: update expected output for battery_ok / battery_mV

### DIFF
--- a/tests/fineoffset/fineoffset_wh52/gfile001.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile001.json
@@ -1,2 +1,2 @@
-{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity" : 106.758, "battery_V" : 1.560, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity" : 5.508, "battery_V" : 1.620, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity" : 106.758, "battery_ok" : 1, "battery_pct" : 86.667, "battery_mV" : 1560, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity" : 5.508, "battery_ok" : 1, "battery_pct" : 100.000, "battery_mV" : 1620, "boost" : 0, "mic" : "CRC"}

--- a/tests/fineoffset/fineoffset_wh52/gfile002.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile002.json
@@ -1,2 +1,2 @@
-{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity" : 56.172, "battery_V" : 1.580, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity" : 25.508, "battery_V" : 1.580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity" : 56.172, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity" : 25.508, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}


### PR DESCRIPTION
Pairs with the companion Fineoffset-WH52 decoder PR merbanan/rtl_433#3636, which switches the WH52 battery reporting from `battery_V` to `battery_ok` + `battery_mV` (matching the WH51 sibling decoder). This updates the expected output for the two WH52 captures so the regression stays green.

Only the battery field changed — `id`, `temperature_C`, `moisture`, `conductivity`, `boost`, `mic` are untouched. The new values follow directly from the raw byte the old `battery_V` was derived from:

| id | old `battery_V` | new `battery_mV` | new `battery_ok` |
|---|---|---|---|
| 0058ac | 1.560 | 1560 | 0.9 |
| 005995 | 1.620 | 1620 | 1.0 |
| 005cb5 | 1.580 | 1580 | 0.9 |
| 005b45 | 1.580 | 1580 | 0.9 |

Best merged together with (or just after) the decoder PR. Thanks!