### PR TITLE
Fix wh52 battery reporting 2

### DIFF
--- a/tests/fineoffset/fineoffset_wh52/gfile001.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile001.json
@@ -1,2 +1,2 @@
-{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity" : 106.758, "battery_V" : 1.560, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity" : 5.508, "battery_V" : 1.620, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity" : 106.758, "battery_ok" : 1, "battery_pct" : 86.667, "battery_mV" : 1560, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity" : 5.508, "battery_ok" : 1, "battery_pct" : 100.000, "battery_mV" : 1620, "boost" : 0, "mic" : "CRC"}

--- a/tests/fineoffset/fineoffset_wh52/gfile001.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile001.json
@@ -1,2 +1,2 @@
-{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity" : 106.758, "battery_ok" : 1, "battery_pct" : 86.667, "battery_mV" : 1560, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity" : 5.508, "battery_ok" : 1, "battery_pct" : 100.000, "battery_mV" : 1620, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.007724s", "model" : "Fineoffset-WH52", "id" : "0058ac", "temperature_C" : 20.400, "moisture" : 44, "conductivity_uS_cm" : 106.758, "battery_ok" : 0.933, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042564s", "model" : "Fineoffset-WH52", "id" : "005995", "temperature_C" : 18.400, "moisture" : 36, "conductivity_uS_cm" : 5.508, "battery_ok" : 1.0, "battery_mV" : 1620, "boost" : 0, "mic" : "CRC"}

--- a/tests/fineoffset/fineoffset_wh52/gfile002.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile002.json
@@ -1,2 +1,2 @@
-{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity" : 56.172, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity" : 25.508, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity_uS_cm" : 56.172, "battery_ok" : 0.933, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity_uS_cm" : 25.508, "battery_ok" : 0.867, "battery_mV" : 1560, "boost" : 0, "mic" : "CRC"}

--- a/tests/fineoffset/fineoffset_wh52/gfile002.json
+++ b/tests/fineoffset/fineoffset_wh52/gfile002.json
@@ -1,2 +1,2 @@
-{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity" : 56.172, "battery_V" : 1.580, "boost" : 0, "mic" : "CRC"}
-{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity" : 25.508, "battery_V" : 1.580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.011008s", "model" : "Fineoffset-WH52", "id" : "005cb5", "temperature_C" : 20.700, "moisture" : 25, "conductivity" : 56.172, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}
+{"time" : "@0.042116s", "model" : "Fineoffset-WH52", "id" : "005b45", "temperature_C" : 21.000, "moisture" : 34, "conductivity" : 25.508, "battery_ok" : 1, "battery_pct" : 93.333, "battery_mV" : 1580, "boost" : 0, "mic" : "CRC"}


### PR DESCRIPTION
Pairs with WH52 battery and conductivity reporting fix https://github.com/merbanan/rtl_433/pull/3668.

WH52 battery voltage calculated from byte 20, not byte 15 (based on empirical observations).
Report battery data according to documented data format (single battery_ok in 0.0 .. 0.1 range).
Renamed conductivity to conductivity_uS_cm for consistency and clarity.

Best merged together with (or just after) the decoder PR. Thanks!